### PR TITLE
Remove static caching from \DrupalCodeGenerator\Utils::getExtensionRoot

### DIFF
--- a/src/Utils.php
+++ b/src/Utils.php
@@ -144,17 +144,14 @@ class Utils {
    *   Extension root directory or false if it was not found.
    */
   public static function getExtensionRoot($directory) {
-    static $extension_root;
-    if ($extension_root === NULL) {
-      $extension_root = FALSE;
-      for ($i = 1; $i <= 5; $i++) {
-        $info_file = $directory . '/' . basename($directory) . '.info';
-        if (file_exists($info_file) || file_exists($info_file . '.yml')) {
-          $extension_root = $directory;
-          break;
-        }
-        $directory = dirname($directory);
+    $extension_root = FALSE;
+    for ($i = 1; $i <= 5; $i++) {
+      $info_file = $directory . '/' . basename($directory) . '.info';
+      if (file_exists($info_file) || file_exists($info_file . '.yml')) {
+        $extension_root = $directory;
+        break;
       }
+      $directory = dirname($directory);
     }
     return $extension_root;
   }


### PR DESCRIPTION
This static variable doesn't buy us much and it actively harms when passing --directory in a `drush generate` command. This method gets called with multiple values in a Drush request. In this case, the first call determines the return value forever.

This PR is mostly an indentation change. All it does of note is remove a static variable.