### PR TITLE
Update composer.twig

### DIFF
--- a/templates/d8/composer.twig
+++ b/templates/d8/composer.twig
@@ -2,7 +2,7 @@
   "name": "drupal/{{ machine_name }}",
   "type": "{{ type }}",
   "description": "{{ description }}",
-  "keywords": ["Drupal"],
+  "keywords": ["Drupal"]{{ drupal_org ? ',' }}
 {% if (drupal_org) %}
   "license": "GPL-2.0+",
   "homepage": "https://www.drupal.org/project/{{ machine_name }}",


### PR DESCRIPTION
Improved comma for project not being on drupal.org

Problem
-----------

If generate composer.json file answering "No" (default value) to question "[Is this project hosted on drupal.org?](https://github.com/Chi-teck/drupal-code-generator/blob/master/src/Command/Drupal_8/Composer.php#L38)", then file generated with invalid markup. It's include comma at the end of `"keywords": ["Drupal"],` which is not expected here.

Steps to reproduce
------------------------

1. `drush generate composer`.
2. Enter project name.
3. Enter project description.
4. Enter project type.
5. On question "Is this project hosted on drupal.org?" answer "No", or press Enter for default value (No).
6. Generated composer.json will be invalid.

```json
{
  "name": "drupal/example",
  "type": "drupal-custom-module",
  "description": "Custom descriptions",
  "keywords": ["Drupal"],
------ error -----------^
}
```
