### PR TITLE
Remove deprecated drupal_set_message() function from install.twig template

### DIFF
--- a/templates/d8/install.twig
+++ b/templates/d8/install.twig
@@ -9,14 +9,14 @@
  * Implements hook_install().
  */
 function {{ machine_name }}_install() {
-  drupal_set_message(__FUNCTION__);
+  \Drupal::messenger()->addStatus(__FUNCTION__);
 }
 
 /**
  * Implements hook_uninstall().
  */
 function {{ machine_name }}_uninstall() {
-  drupal_set_message(__FUNCTION__);
+  \Drupal::messenger()->addStatus(__FUNCTION__);
 }
 
 /**

--- a/templates/d8/install.twig
+++ b/templates/d8/install.twig
@@ -9,14 +9,14 @@
  * Implements hook_install().
  */
 function {{ machine_name }}_install() {
-  \Drupal::messenger()->addStatus(__FUNCTION__);
+  // @DCG Place your code here.
 }
 
 /**
  * Implements hook_uninstall().
  */
 function {{ machine_name }}_uninstall() {
-  \Drupal::messenger()->addStatus(__FUNCTION__);
+  // @DCG Place your code here.
 }
 
 /**

--- a/tests/dcg/Generator/Drupal_8/Module/_standard/foo.install
+++ b/tests/dcg/Generator/Drupal_8/Module/_standard/foo.install
@@ -9,14 +9,14 @@
  * Implements hook_install().
  */
 function foo_install() {
-  drupal_set_message(__FUNCTION__);
+  // @DCG Place your code here.
 }
 
 /**
  * Implements hook_uninstall().
  */
 function foo_uninstall() {
-  drupal_set_message(__FUNCTION__);
+  // @DCG Place your code here.
 }
 
 /**

--- a/tests/dcg/Generator/Drupal_8/_.install
+++ b/tests/dcg/Generator/Drupal_8/_.install
@@ -9,14 +9,14 @@
  * Implements hook_install().
  */
 function foo_install() {
-  drupal_set_message(__FUNCTION__);
+  // @DCG Place your code here.
 }
 
 /**
  * Implements hook_uninstall().
  */
 function foo_uninstall() {
-  drupal_set_message(__FUNCTION__);
+  // @DCG Place your code here.
 }
 
 /**


### PR DESCRIPTION
Replaced deprecated `drupal_set_message()` with Drupal::messenger().

[drupal_get_message() and drupal_set_message() replaced by Messenger service](https://www.drupal.org/node/2774931)