### PR TITLE
Update ExampleType.php.twig

### DIFF
--- a/templates/d8/module/content-entity/src/Entity/ExampleType.php.twig
+++ b/templates/d8/module/content-entity/src/Entity/ExampleType.php.twig
@@ -32,7 +32,7 @@ use Drupal\Core\Config\Entity\ConfigEntityBundleBase;
  *   links = {
  *     "add-form" = "/admin/structure/{{ entity_type_id }}_types/add",
  *     "edit-form" = "/admin/structure/{{ entity_type_id }}_types/manage/{{ '{' ~ entity_type_id ~ '_type}' }}",
- *     "delete-form" = "/admin/structure/{{ entity_type_id }}_types/manage/{{ '{' ~ entity_type_id ~ ' _type}' }}/delete",
+ *     "delete-form" = "/admin/structure/{{ entity_type_id }}_types/manage/{{ '{' ~ entity_type_id ~ '_type}' }}/delete",
  *     "collection" = "/admin/structure/{{ entity_type_id }}_types"
  *   },
  *   config_export = {


### PR DESCRIPTION
Content entity type mispell in "delete-form" URL.

Currently value in twig is generated with this code:

```twig
"delete-form" = "/admin/structure/{{ entity_type_id }}_types/manage/{{ '{' ~ entity_type_id ~ ' _type}' }}/delete",
```

And the problem is in `{' ~ entity_type_id ~ ' _type}` part. Where is a space before `_type`, which generate this link incorrectly.

If `entity_type_id` is `node`, than currently url will be: `"/admin/structure/node_types/manage/node _/delete"`, but correct one is `"/admin/structure/node_types/manage/node_/delete"`