### PR TITLE
Update Example.php.twig

### DIFF
--- a/templates/d8/module/content-entity/src/Entity/Example.php.twig
+++ b/templates/d8/module/content-entity/src/Entity/Example.php.twig
@@ -52,10 +52,16 @@ use Drupal\Core\Entity\EntityChangedTrait;
  *     }
  *   },
  *   base_table = "{{ entity_type_id }}",
+{% if translatable %}
  *   data_table = "{{ entity_type_id }}_field_data",
+{% endif %}
 {% if revisionable %}
  *   revision_table = "{{ entity_type_id }}_revision",
+{% endif %}
+{% if revisionable and translatable %}
  *   revision_data_table = "{{ entity_type_id }}_field_revision",
+{% endif %}
+{% if revisionable %}
  *   show_revision_ui = TRUE,
 {% endif %}
 {% if translatable %}


### PR DESCRIPTION
data_table only used when entity is translatable, and don't need to be set when is not. This mess up Views and possible others.

Problem
=======

When we generate entity type, the `base_table` annotation value is set every time. This table only used [when entity is translatable](https://drupal.stackexchange.com/questions/155620/what-is-the-difference-between-base-tables-and-data-tables-for-content-entities). So when user enable generated module, Drupal  detect that entity is not translatable and don't create that table. But! Views can't handle this.

ViewsEntityRow.php:97 has this code:

```php
          'base' => [$entity_type->getDataTable() ?: $entity_type->getBaseTable()],
```

So there is the problem. Views sees that data table is set, but there is no table for it. And when we create views, it attached to `base_table`, but plugin generated for `data_table`. So in current state, custom entity is not able to be rendered in views, only Field mode is available.

Proposed solution
==============

It's partialy drupal code generator problem. This confusing developers a little bit by generate not necessary definition in `@ContentEntityType` annotation. So form part of this project, I suggest to add `data_table` only when entity is translatable, otherwise, this is just not needed value, which cause some problems with other modules.

Steps to reproduce
===============

1. Generate content entity module.
2. Answer to **Make the entity type translatable?** question **No** (default value).
3. Create some entities.
4. Create views to display entities of this entity type.
5. Try to selected row plugin as Rendered entity, it will be missing. Only Fields will be available.