### PR TITLE
Don't set default value for uid if there is no author base field.

### DIFF
--- a/templates/d8/module/content-entity/src/Entity/Example.php.twig
+++ b/templates/d8/module/content-entity/src/Entity/Example.php.twig
@@ -127,7 +127,9 @@ class {{ class_prefix }} extends {% if revisionable %}Revisionable{% endif %}Con
    */
   public static function preCreate(EntityStorageInterface $storage_controller, array &$values) {
     parent::preCreate($storage_controller, $values);
+{% if author_base_field %}
     $values += ['uid' => \Drupal::currentUser()->id()];
+{% endif %}
   }
 
 {% if title_base_field %}

--- a/templates/d8/module/content-entity/src/Entity/Example.php.twig
+++ b/templates/d8/module/content-entity/src/Entity/Example.php.twig
@@ -119,6 +119,7 @@ class {{ class_prefix }} extends {% if revisionable %}Revisionable{% endif %}Con
   use EntityChangedTrait;
 
 {% endif %}
+{% if author_base_field %}
   /**
    * {@inheritdoc}
    *
@@ -127,11 +128,10 @@ class {{ class_prefix }} extends {% if revisionable %}Revisionable{% endif %}Con
    */
   public static function preCreate(EntityStorageInterface $storage_controller, array &$values) {
     parent::preCreate($storage_controller, $values);
-{% if author_base_field %}
     $values += ['uid' => \Drupal::currentUser()->id()];
-{% endif %}
   }
 
+{% endif %}
 {% if title_base_field %}
   /**
    * {@inheritdoc}


### PR DESCRIPTION
Currently, if generate without author base field, the default value for uid is presented.