### PR TITLE
Browser and Kernel advanced test case generator.

### DIFF
--- a/src/Command/Drupal_8/Test/AdvancedBase.php
+++ b/src/Command/Drupal_8/Test/AdvancedBase.php
@@ -1,0 +1,104 @@
+<?php
+
+namespace DrupalCodeGenerator\Command\Drupal_8\Test;
+
+use DrupalCodeGenerator\Command\BaseGenerator;
+use DrupalCodeGenerator\Utils;
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Output\OutputInterface;
+use Symfony\Component\Console\Question\ChoiceQuestion;
+use Symfony\Component\Console\Question\Question;
+
+/**
+ * Abstract class AdvancedTest.
+ */
+abstract class AdvancedBase extends BaseGenerator {
+
+  /**
+   * Get answer for Options selected.
+   */
+  protected $type;
+
+  /**
+   * Interacts with the user and builds route variables.
+   */
+  protected function advancedTypeInteraction(InputInterface $input, OutputInterface $output) {
+
+    // Prepare options for test creation.
+    $default_types = $types = $this->getOptions();
+    while(TRUE) {
+      $choices = Utils::prepareChoices($types);
+      $type_question = new ChoiceQuestion('Select Type', $choices, '');
+      $type_answer = $this->ask($input, $output, $type_question);
+
+      $this->type = array_search($type_answer, $types);
+
+      $child_types = $this->getOptions($this->type);
+      if (!is_array($child_types) || $child_types == $default_types) {
+        break;
+      }
+      $types = $child_types;
+    }
+  }
+
+  /**
+   * Function to get options for questions.
+   *
+   * @param string $type
+   *  Type of question need to retrieve.
+   *
+   * @return array $options
+   *   Options to return.
+   */
+  protected function getOptions($type = NULL) {
+
+    // Prepare options for test creation.
+    $options = [
+      'plugin' => 'Plugin',
+      'controller' => 'Controller',
+      'service' => 'Service',
+    ];
+
+    if ($type && array_key_exists($type, $options)) {
+      $options = $options[$type];
+    }
+
+    return $options;
+  }
+
+  /**
+   * Function to get options for questions.
+   *
+   * @param string $type
+   *  Type of question need to retrieve.
+   *
+   * @return array $questions
+   *   Options to return.
+   */
+  protected function getTypeQuestions($type = NULL) {
+
+    $questions = [];
+
+    switch ($type) {
+      case 'block':
+        $questions[$type] = new Question('Enter Block name', 'example');
+        break;
+      case 'field-type':
+        $questions[$type] = new Question('Enter Field Type', 'example');
+        break;
+      case 'formatter':
+        $questions[$type] = new Question('Enter Field Formatter', 'example');
+        break;
+      case 'controller':
+        $questions['route_path'] = new Question('Route path', '/example/route');
+        $questions['route_permission'] = new Question('Route permission', 'access content');
+        break;
+      case 'service':
+        $questions[$type] = new Question('Service name', '{machine_name}.example');
+        $questions[$type]->setValidator([Utils::class, 'validateServiceName']);
+        break;
+    }
+    return $questions;
+  }
+
+}

--- a/src/Command/Drupal_8/Test/BrowserAdvanced.php
+++ b/src/Command/Drupal_8/Test/BrowserAdvanced.php
@@ -1,0 +1,84 @@
+<?php
+
+namespace DrupalCodeGenerator\Command\Drupal_8\Test;
+
+use DrupalCodeGenerator\Utils;
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Output\OutputInterface;
+use Symfony\Component\Console\Question\Question;
+
+class BrowserAdvanced extends AdvancedBase {
+
+  protected $name = 'd8:test:browser-advanced';
+  protected $description = 'Generates advanced browser based test';
+  protected $alias = 'browser-test-advanced';
+
+  /**
+   * {@inheritdoc}
+   */
+  protected function interact(InputInterface $input, OutputInterface $output) {
+
+    parent::advancedTypeInteraction($input, $output);
+    if ($this->type) {
+
+      // Let's get Questions for specific type.
+      $default_questions = $this->getTypeQuestions($this->type);
+
+      // Let's map default questions.
+      $default_questions += Utils::moduleQuestions();
+
+      $default_questions['class'] = new Question('Class', 'ExampleTest');
+      $default_questions['class']->setValidator([
+        Utils::class,
+        'validateClassName'
+      ]);
+
+      $this->collectVars($input, $output, $default_questions);
+      $twig_path = "d8/test/browser-advanced/{$this->type}.twig";
+      switch ($this->type) {
+
+        case 'block':
+          $twig_path = "d8/test/browser-advanced/plugin/{$this->type}.twig";
+          break;
+      }
+
+      $this->addFile()
+        ->path("tests/src/Functional/{class}.php")
+        ->template($twig_path);
+    }
+  }
+
+  /**
+   * Function to get options for questions.
+   *
+   * @param string $type
+   *  Type of question need to retrieve.
+   *
+   * @return array $options
+   *   Options to return.
+   */
+  protected function getOptions($type = NULL) {
+
+    // Prepare options for test creation.
+    $options = [
+      'plugin' => 'Plugin',
+      'controller' => 'Controller'
+    ];
+
+    switch ($type) {
+
+      case 'plugin':
+        $options['plugin'] = [
+          'block' => 'Block',
+        ];
+        break;
+    }
+
+    if ($type && array_key_exists($type, $options)) {
+      $options = $options[$type];
+    }
+
+    return $options;
+  }
+
+}

--- a/src/Command/Drupal_8/Test/KernelAdvanced.php
+++ b/src/Command/Drupal_8/Test/KernelAdvanced.php
@@ -1,0 +1,59 @@
+<?php
+
+namespace DrupalCodeGenerator\Command\Drupal_8\Test;
+
+use DrupalCodeGenerator\Utils;
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Output\OutputInterface;
+use Symfony\Component\Console\Question\Question;
+
+class KernelAdvanced extends AdvancedBase {
+
+  protected $name = 'd8:test:kernel-advanced';
+  protected $description = 'Generates advanced kernel based test';
+  protected $alias = 'kernel-test-advanced';
+
+  /**
+   * {@inheritdoc}
+   */
+  protected function interact(InputInterface $input, OutputInterface $output) {
+
+    parent::advancedTypeInteraction($input, $output);
+    if ($this->type) {
+
+      // Let's get Questions for specific type.
+      $default_questions = $this->getTypeQuestions($this->type);
+
+      // Let's map default questions.
+      $default_questions += Utils::moduleQuestions();
+
+      $default_questions['class'] = new Question('Class', 'ExampleTest');
+      $default_questions['class']->setValidator([Utils::class, 'validateClassName']);
+
+      $this->collectVars($input, $output, $default_questions);
+
+      $this->addFile()
+        ->path("tests/src/Kernel/{class}.php")
+        ->template("d8/test/kernel-advanced/{$this->type}.twig");
+    }
+  }
+
+  /**
+   * Function to get options for questions.
+   *
+   * @param string $type
+   *  Type of question need to retrieve.
+   *
+   * @return array $options
+   *   Options to return.
+   */
+  protected function getOptions($type = NULL) {
+
+    // Prepare options for test creation.
+    $options = [
+      'service' => 'Service',
+    ];
+
+    return $options;
+  }
+}

--- a/templates/d8/test/browser-advanced/controller.twig
+++ b/templates/d8/test/browser-advanced/controller.twig
@@ -1,0 +1,44 @@
+<?php
+
+namespace Drupal\Tests\{{ machine_name }}\Functional;
+
+use Drupal\KernelTests\BrowserTestBase;
+
+/**
+ * Test description.
+ *
+ * @group {{ machine_name }}
+ */
+class {{ class }} extends BrowserTestBase {
+
+  /**
+   * {@inheritdoc}
+   */
+  public static $modules = ['{{ machine_name }}'];
+
+  /**
+   * A user with permission to access controller.
+   *
+   * @var object
+   */
+  protected $webUser;
+
+  /**
+   * {@inheritdoc}
+   */
+  protected function setUp() {
+    parent::setUp();
+    $this->webUser = $this->drupalCreateUser(['{{ route_permission }}']);
+  }
+
+  /**
+   * Test callback.
+   */
+  public function testController() {
+    $this->drupalLogin($this->webUser);
+
+    // Validate route.
+    $this->drupalGet('{{ route_path }}');
+    $this->assertSession()->statusCodeEquals(200);
+  }
+}

--- a/templates/d8/test/browser-advanced/plugin/block.twig
+++ b/templates/d8/test/browser-advanced/plugin/block.twig
@@ -1,0 +1,69 @@
+<?php
+
+namespace Drupal\Tests\{{ machine_name }}\Functional;
+
+use Drupal\Tests\BrowserTestBase;
+use Drupal\block\Entity\Block;
+
+/**
+ * Test description.
+ *
+ * @group {{ machine_name }}
+ */
+class {{ class }} extends BrowserTestBase {
+
+  /**
+   * {@inheritdoc}
+   */
+  public static $modules = ['{{ machine_name }}', 'block'];
+
+  /**
+   * {@inheritdoc}
+   */
+  protected function setUp() {
+    parent::setUp();
+    // Set up the test here.
+  }
+
+  /**
+   * Test configuring and moving a module-define block to specific regions.
+   */
+  public function testBlock() {
+    // Place MyBockTest block to test error messages.
+    $this->drupalPlaceBlock('{{ block }}');
+
+    // Disable the block.
+    $this->drupalGet('admin/structure/block');
+    $this->clickLink('Disable');
+
+    // Select the MyBockTest block to be configured and moved.
+    $block = [];
+    $block['id'] = '{{ block }}';
+    $block['settings[label]'] = $this->randomMachineName(8);
+    $block['settings[label_display]'] = TRUE;
+    $block['theme'] = $this->config('system.theme')->get('default');
+    $block['region'] = 'header';
+
+    // Set block title to confirm that interface works and override any custom titles.
+    $this->drupalPostForm('admin/structure/block/add/' . $block['id'] . '/' . $block['theme'], ['settings[label]' => $block['settings[label]'], 'settings[label_display]' => $block['settings[label_display]'], 'id' => $block['id'], 'region' => $block['region']], t('Save block'));
+    $this->assertText(t('The block configuration has been saved.'), 'Block title set.');
+    // Check to see if the block was created by checking its configuration.
+    $instance = Block::load($block['id']);
+
+    $this->assertEqual($instance->label(), $block['settings[label]'], 'Stored block title found.');
+  }
+
+  /**
+   * Tests block visibility.
+   */
+  public function testBlockVisibility() {
+    // Test Block visibility.
+  }
+
+  /**
+   * Tests the block access.
+   */
+  public function testBlockAccess() {
+    // Test Block visibility.
+  }
+}

--- a/templates/d8/test/kernel-advanced/service.twig
+++ b/templates/d8/test/kernel-advanced/service.twig
@@ -1,0 +1,35 @@
+<?php
+
+namespace Drupal\Tests\{{ machine_name }}\Kernel;
+
+use Drupal\Tests\KernelTestBase;
+
+/**
+ * Test description.
+ *
+ * @group {{ machine_name }}
+ */
+class {{ class }} extends KernelTestBase {
+
+  /**
+   * {@inheritdoc}
+   */
+  public static $modules = ['{{ machine_name }}'];
+
+  /**
+   * {@inheritdoc}
+   */
+  protected function setUp() {
+    parent::setUp();
+    // Set up the test here.
+  }
+
+  /**
+   * Test service exists.
+   */
+  public function testService() {
+
+    $service = \Drupal::srvice('{{ service }}');
+    $this->assertNotEmpty($service, 'Service is available');
+   }
+}

--- a/templates/d8/test/kernel-advanced/service.twig
+++ b/templates/d8/test/kernel-advanced/service.twig
@@ -29,7 +29,7 @@ class {{ class }} extends KernelTestBase {
    */
   public function testService() {
 
-    $service = \Drupal::srvice('{{ service }}');
+    $service = \Drupal::service('{{ service }}');
     $this->assertNotEmpty($service, 'Service is available');
    }
 }


### PR DESCRIPTION
**Feature:** Generating advanced kernel and browser test cases.

- Provide options to generate advanced kernel and browser test cases.
- Currently, it supports generating test cases for block plugin, Controller (Browser), Service (Kernel) test cases.

Command:
1. drush generate test-browser-advanced
2. drush generate test-kernel-advanced