### PR TITLE
Fixes #47: Alias classes only if they haven't been aliased before.

### DIFF
--- a/src/bootstrap.php
+++ b/src/bootstrap.php
@@ -41,7 +41,11 @@ list($twig_major_version) = sscanf(Environment::VERSION, '%d.%d.%d');
 // it is not possible to maintain the same \Twig\Environment sub-class for both
 // Twig versions.
 $twig_environment_class = sprintf('DrupalCodeGenerator\Twig\Twig%dEnvironment', $twig_major_version);
-class_alias($twig_environment_class, 'DrupalCodeGenerator\Twig\TwigEnvironment');
+if (!class_exists('DrupalCodeGenerator\Twig\TwigEnvironment')) {
+  class_alias($twig_environment_class, 'DrupalCodeGenerator\Twig\TwigEnvironment');
+}
 
 // Legacy TwigEnvironment class is still used in Drush.
-class_alias($twig_environment_class, 'DrupalCodeGenerator\TwigEnvironment');
+if (!class_exists('DrupalCodeGenerator\TwigEnvironment')) {
+  class_alias($twig_environment_class, 'DrupalCodeGenerator\TwigEnvironment');
+}


### PR DESCRIPTION
This fix removes the warnings I described in #47. I also verified that the code generation still works as expected.