### PR TITLE
Add support for other Drupal specific package types into Composer generator

### DIFF
--- a/src/Command/Composer.php
+++ b/src/Command/Composer.php
@@ -37,7 +37,12 @@ final class Composer extends DrupalGenerator {
     ]);
     $vars['type'] = $this->io->askQuestion($type_question);
 
-    if (!in_array($vars['type'], ['drupal-custom-module', 'drupal-custom-theme', 'drupal-custom-profile'])) {
+    $custom_types = [
+      'drupal-custom-module',
+      'drupal-custom-theme',
+      'drupal-custom-profile',
+    ];
+    if (!\in_array($vars['type'], $custom_types)) {
       // If project type is custom, there is no reason to ask this.
       $vars['drupal_org'] = $this->confirm('Is this project hosted on drupal.org?', FALSE);
     }

--- a/src/Command/Composer.php
+++ b/src/Command/Composer.php
@@ -27,14 +27,23 @@ final class Composer extends DrupalGenerator {
     $type_question->setValidator([self::class, 'validateRequired']);
     $type_question->setAutocompleterValues([
       'drupal-module',
+      'drupal-custom-module',
       'drupal-theme',
+      'drupal-custom-theme',
       'drupal-library',
       'drupal-profile',
+      'drupal-custom-profile',
       'drupal-drush',
     ]);
     $vars['type'] = $this->io->askQuestion($type_question);
 
-    $vars['drupal_org'] = $this->confirm('Is this project hosted on drupal.org?', FALSE);
+    if (!in_array($vars['type'], ['drupal-custom-module', 'drupal-custom-theme', 'drupal-custom-profile'])) {
+      // If project type is custom, there is no reason to ask this.
+      $vars['drupal_org'] = $this->confirm('Is this project hosted on drupal.org?', FALSE);
+    }
+    else {
+      $vars['drupal_org'] = FALSE;
+    }
 
     $this->addFile('composer.json', 'composer');
   }


### PR DESCRIPTION
Drupal's default [composer template](https://github.com/drupal/recommended-project/blob/8.8.x/composer.json#L47-L48) supports for additional types: `drupal-custom-module` and `drupal-custom-theme`.

Also, in the future release core adds support for `drupal-custom-profile`.

I propose to add them into suggestions.

Since custom package types 100% not published at drupal.org, I also added condition to skip this question, since it makes no sense.