### PR TITLE
::save() method in content entity form can call parent method

### DIFF
--- a/templates/content-entity/src/Form/ExampleForm.php.twig
+++ b/templates/content-entity/src/Form/ExampleForm.php.twig
@@ -14,9 +14,7 @@ class {{ class_prefix }}Form extends ContentEntityForm {
    * {@inheritdoc}
    */
   public function save(array $form, FormStateInterface $form_state) {
-
-    $entity = $this->getEntity();
-    $result = $entity->save();
+    $result = parent::save($form, $form_state);
 
     $message_arguments = ['%label' => $this->entity->toLink()->toString()];
     $logger_arguments = [

--- a/tests/dcg/Generator/_content_entity/src/Form/ExampleForm.php
+++ b/tests/dcg/Generator/_content_entity/src/Form/ExampleForm.php
@@ -14,9 +14,7 @@ class FooExampleForm extends ContentEntityForm {
    * {@inheritdoc}
    */
   public function save(array $form, FormStateInterface $form_state) {
-
-    $entity = $this->getEntity();
-    $result = $entity->save();
+    $result = parent::save($form, $form_state);
 
     $message_arguments = ['%label' => $this->entity->toLink()->toString()];
     $logger_arguments = [


### PR DESCRIPTION
The generated edit form for a content entity currently copies the logic from the parent method. It is a better practice to instead call the parent method.