### PR TITLE
Remove unneeded entity_class manipulation in twig

### DIFF
--- a/templates/entity-bundle-class/bundle-base-class.twig
+++ b/templates/entity-bundle-class/bundle-base-class.twig
@@ -7,6 +7,6 @@ use {{ entity_class_fqn }};
 /**
  * A base bundle class for {{ entity_type_id }} entities.
  */
-abstract class {{ base_class }} extends {{ entity_class|split('\\')|last }} {
+abstract class {{ base_class }} extends {{ entity_class }} {
 
 }


### PR DESCRIPTION
Looks like moved this to PHP so this Twig is unneeded.