### PR TITLE
Shorten bundle class alias

### DIFF
--- a/src/Command/Entity/EntityBundleClass.php
+++ b/src/Command/Entity/EntityBundleClass.php
@@ -22,7 +22,7 @@ final class EntityBundleClass extends ModuleGenerator {
   protected string $name = 'entity:bundle-class';
   protected string $description = 'Generate a bundle class for a content entity.';
   protected string $templatePath = Application::TEMPLATE_PATH . '/entity-bundle-class';
-  protected string $alias = 'entity-bundle-class';
+  protected string $alias = 'bundle-class';
 
   /**
    * {@inheritdoc}


### PR DESCRIPTION
The other entity: commands do not put `entity-` in their alias so this adds consistency and reduces typing. Further, Drush removes the alias because it tries not to show "redundant" aliases. [That code](https://github.com/drush-ops/drush/blame/74a2c4214095d31b07768b6ac588350e977b1db5/src/Commands/help/ListCommands.php#L136-L143) is meant mainly for commands and not generators but this PR solves both issues.