### PR TITLE
Symfony string 6

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -30,10 +30,10 @@
         "php": ">=7.4",
         "ext-json": "*",
         "psr/log": "^1.1",
-        "symfony/console": "^4.4.15 || ^5.1",
-        "symfony/filesystem": "^4.4 || ^5.1",
+        "symfony/console": "^4.4.15 || ^5.1 || ^6",
+        "symfony/filesystem": "^4.4 || ^5.1 || ^6",
         "symfony/polyfill-php80": "^1.23",
-        "symfony/string": "^5.1",
+        "symfony/string": "^5.1 || ^6",
         "twig/twig": "^2.12 || ^3.1"
     },
     "require-dev": {

--- a/composer.json
+++ b/composer.json
@@ -30,8 +30,8 @@
         "php": ">=7.4",
         "ext-json": "*",
         "psr/log": "^1.1",
-        "symfony/console": "^4.4.15 || ^5.1 || ^6",
-        "symfony/filesystem": "^4.4 || ^5.1 || ^6",
+        "symfony/console": "^4.4.15 || ^5.1",
+        "symfony/filesystem": "^4.4 || ^5.1",
         "symfony/polyfill-php80": "^1.23",
         "symfony/string": "^5.1 || ^6",
         "twig/twig": "^2.12 || ^3.1"


### PR DESCRIPTION
In order to allow easy install of Drush on Drupal 10 which will ship with Symfony 6 and already locks to symfony/string 6