### PR TITLE
Allow symfony/filesystem v6

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -31,7 +31,7 @@
         "ext-json": "*",
         "psr/log": "^1.1",
         "symfony/console": "^4.4.15 || ^5.1",
-        "symfony/filesystem": "^4.4 || ^5.1",
+        "symfony/filesystem": "^4.4 || ^5.1 || ^6",
         "symfony/polyfill-php80": "^1.23",
         "symfony/string": "^5.1 || ^6",
         "twig/twig": "^2.12 || ^3.1"


### PR DESCRIPTION
I was able to install this package with symfony/filesystem v6, but I also had to allow the dev-master version of friendsoftwig/twigcs as there is not yet a compatible release of that package.