### PR TITLE
Allow livereload to watch files in all theme subdirectories

### DIFF
--- a/templates/theme/package.json.twig
+++ b/templates/theme/package.json.twig
@@ -2,7 +2,7 @@
   "name": "{{ machine_name }}",
   "private": true,
   "scripts": {
-    "livereload": "livereload -d"
+    "livereload": "livereload --exclusions node_modules/ --exts 'css,js,twig,theme,apng,avif,gif,jpg,jpeg,jfif,pjpeg,pjp,png,svg,webp'"
   },
   "devDependencies": {
     "livereload": "^0.9.3"

--- a/templates/theme/package.json.twig
+++ b/templates/theme/package.json.twig
@@ -2,7 +2,7 @@
   "name": "{{ machine_name }}",
   "private": true,
   "scripts": {
-    "livereload": "livereload css"
+    "livereload": "livereload -d"
   },
   "devDependencies": {
     "livereload": "^0.9.3"

--- a/tests/dcg/Generator/_theme/package.json
+++ b/tests/dcg/Generator/_theme/package.json
@@ -2,7 +2,7 @@
   "name": "foo",
   "private": true,
   "scripts": {
-    "livereload": "livereload css"
+    "livereload": "livereload -d"
   },
   "devDependencies": {
     "livereload": "^0.9.3"

--- a/tests/dcg/Generator/_theme/package.json
+++ b/tests/dcg/Generator/_theme/package.json
@@ -2,7 +2,7 @@
   "name": "foo",
   "private": true,
   "scripts": {
-    "livereload": "livereload -d"
+    "livereload": "livereload --exclusions node_modules/ --exts 'css,js,twig,theme,apng,avif,gif,jpg,jpeg,jfif,pjpeg,pjp,png,svg,webp'"
   },
   "devDependencies": {
     "livereload": "^0.9.3"


### PR DESCRIPTION
Livereload per default watches the following file extensions: 'html,css,js,png,gif,jpg,php,php5,py,rb,erb,coffee'
But is configured to only watch the css directory.

It might make sense to just watch all the theme's subdirectories, including css, js, images.
Also adding the -d flag for more verbosity.