### PR TITLE
Add phpstorm metadata for ContainerInterface

### DIFF
--- a/scripts/sut-tests.sh
+++ b/scripts/sut-tests.sh
@@ -102,7 +102,8 @@ fi
 
 echo '🚩 Install local DCG'
 composer -d"$DRUPAL_DIR" config repositories.dcg "$(printf '{"type": "path", "url": "%s", "options": {"symlink": false}}' $SELF_DIR)"
-composer -d$DRUPAL_DIR require chi-teck/drupal-code-generator:3.x
+composer -d$DRUPAL_DIR info --available chi-teck/drupal-code-generator
+composer -d$DRUPAL_DIR require chi-teck/drupal-code-generator
 
 echo '🚩 Start server'
 symfony server:start --daemon --dir=$DRUPAL_DIR --port=$DCG_DRUPAL_PORT --no-tls

--- a/scripts/sut-tests.sh
+++ b/scripts/sut-tests.sh
@@ -102,8 +102,10 @@ fi
 
 echo '🚩 Install local DCG'
 composer -d"$DRUPAL_DIR" config repositories.dcg "$(printf '{"type": "path", "url": "%s", "options": {"symlink": false}}' $SELF_DIR)"
-composer -d$DRUPAL_DIR info --available chi-teck/drupal-code-generator
 composer -d$DRUPAL_DIR require chi-teck/drupal-code-generator
+echo '————————————————————————————————————————————'
+composer -d$DRUPAL_DIR show chi-teck/drupal-code-generator
+echo '————————————————————————————————————————————'
 
 echo '🚩 Start server'
 symfony server:start --daemon --dir=$DRUPAL_DIR --port=$DCG_DRUPAL_PORT --no-tls

--- a/templates/phpstorm-metadata/phpstorm.meta.php.twig
+++ b/templates/phpstorm-metadata/phpstorm.meta.php.twig
@@ -10,6 +10,15 @@ namespace PHPSTORM_META {
 {% endfor %}
     ])
   );
+  
+  override(
+    \Symfony\Component\DependencyInjection\ContainerInterface::get(0),
+    map([
+{% for service_id, class in services %}
+      '{{ service_id }}' => '{{ class }}',
+{% endfor %}
+    ])
+  );
 
   override(
     \Drupal\Core\Entity\EntityTypeManagerInterface::getStorage(0),


### PR DESCRIPTION
This is helpful in classes with <code>\Drupal\Core\DependencyInjection\ContainerInjectionInterface</code> for example controllers.