### PR TITLE
FileSystemInterface::prepareDirectory expects a bitmask as argument

### DIFF
--- a/templates/_phpstorm-meta/file_system.php.twig
+++ b/templates/_phpstorm-meta/file_system.php.twig
@@ -5,7 +5,7 @@ namespace PHPSTORM_META {
   expectedArguments(
     \Drupal\Core\File\FileSystemInterface::prepareDirectory(),
     1,
-    \Drupal\Core\File\FileSystemInterface::CREATE_DIRECTORY,
+    \Drupal\Core\File\FileSystemInterface::CREATE_DIRECTORY |
     \Drupal\Core\File\FileSystemInterface::MODIFY_PERMISSIONS
   );
 

--- a/tests/functional/Generator/_phpstorm_meta/.phpstorm.meta.php/file_system.php
+++ b/tests/functional/Generator/_phpstorm_meta/.phpstorm.meta.php/file_system.php
@@ -5,7 +5,7 @@ namespace PHPSTORM_META {
   expectedArguments(
     \Drupal\Core\File\FileSystemInterface::prepareDirectory(),
     1,
-    \Drupal\Core\File\FileSystemInterface::CREATE_DIRECTORY,
+    \Drupal\Core\File\FileSystemInterface::CREATE_DIRECTORY |
     \Drupal\Core\File\FileSystemInterface::MODIFY_PERMISSIONS
   );
 


### PR DESCRIPTION
FileSystemInterface::prepareDirectory uses a bitmask as argument. 

CREATE_DIRECTORY and MODIFY_PERMISSIONS can be used together and PhpStorm metadata has support for this.

https://www.jetbrains.com/help/phpstorm/ide-advanced-metadata.html#expected-arguments 