### PR TITLE
Remove useless argument passing for parent constructor in REST resource

### DIFF
--- a/templates/Plugin/_rest-resource/rest-resource.twig
+++ b/templates/Plugin/_rest-resource/rest-resource.twig
@@ -64,7 +64,7 @@ final class {{ class }} extends ResourceBase {
     LoggerInterface $logger,
     KeyValueFactoryInterface $keyValueFactory,
   ) {
-    parent::__construct($configuration, $plugin_id, $plugin_definition, $serializer_formats, $logger, $keyValueFactory);
+    parent::__construct($configuration, $plugin_id, $plugin_definition, $serializer_formats, $logger);
     $this->storage = $keyValueFactory->get('{{ plugin_id }}');
   }
 

--- a/tests/functional/Generator/Plugin/_rest_resource/src/Plugin/rest/resource/FooResource.php
+++ b/tests/functional/Generator/Plugin/_rest_resource/src/Plugin/rest/resource/FooResource.php
@@ -64,7 +64,7 @@ final class FooResource extends ResourceBase {
     LoggerInterface $logger,
     KeyValueFactoryInterface $keyValueFactory,
   ) {
-    parent::__construct($configuration, $plugin_id, $plugin_definition, $serializer_formats, $logger, $keyValueFactory);
+    parent::__construct($configuration, $plugin_id, $plugin_definition, $serializer_formats, $logger);
     $this->storage = $keyValueFactory->get('example_foo');
   }
 


### PR DESCRIPTION
`\Drupal\rest\Plugin\ResourceBase::__construct()` doesn't expect `KeyValueFactoryInterface $keyValueFactory` parameter, so passing it is useless.