### PR TITLE
SingleDirectoryComponent::__construct should type against interface

### DIFF
--- a/src/Command/SingleDirectoryComponent.php
+++ b/src/Command/SingleDirectoryComponent.php
@@ -2,10 +2,10 @@
 
 namespace DrupalCodeGenerator\Command;
 
+use Drupal\Core\Asset\LibraryDiscoveryInterface;
 use Drupal\Core\Extension\ModuleHandlerInterface;
 use Drupal\Core\Extension\ThemeHandlerInterface;
 use Symfony\Component\DependencyInjection\ContainerInterface;
-use Drupal\Core\Asset\LibraryDiscovery;
 use Drupal\Core\DependencyInjection\ContainerInjectionInterface;
 use DrupalCodeGenerator\Application;
 use DrupalCodeGenerator\Asset\AssetCollection;
@@ -35,7 +35,7 @@ final class SingleDirectoryComponent extends BaseGenerator implements ContainerI
   public function __construct(
     private readonly ModuleHandlerInterface $moduleHandler,
     private readonly ThemeHandlerInterface $themeHandler,
-    private readonly LibraryDiscovery $libraryDiscovery,
+    private readonly LibraryDiscoveryInterface $libraryDiscovery,
   ) {
     parent::__construct();
   }


### PR DESCRIPTION
I try to run `drush generate` and I get this error:

` [error]  TypeError: DrupalCodeGenerator\Command\SingleDirectoryComponent::__construct(): Argument #3 ($libraryDiscovery) must be of type Drupal\Core\Asset\LibraryDiscovery, Drupal\attachinline\Asset\LibraryDiscoveryDecorator given, called in /var/www/vendor/chi-teck/drupal-code-generator/src/Command/SingleDirectoryComponent.php on line 50 in DrupalCodeGenerator\Command\SingleDirectoryComponent->__construct() (line 35 of /var/www/vendor/chi-teck/drupal-code-generator/src/Command/SingleDirectoryComponent.php) #0 /var/www/vendor/chi-teck/drupal-code-generator/src/Command/SingleDirectoryComponent.php(50): DrupalCodeGenerator\Command\SingleDirectoryComponent->__construct(Object(Drupal\Core\Extension\ModuleHandler), Object(Drupal\Core\Extension\ThemeHandler), Object(Drupal\attachinline\Asset\LibraryDiscoveryDecorator))
#1 /var/www/web/core/lib/Drupal/Core/DependencyInjection/ClassResolver.php(28): DrupalCodeGenerator\Command\SingleDirectoryComponent::create(Object(Drupal\Core\DependencyInjection\Container))
#2 /var/www/vendor/chi-teck/drupal-code-generator/src/GeneratorFactory.php(58): Drupal\Core\DependencyInjection\ClassResolver->getInstanceFromDefinition('\\DrupalCodeGene...')
#3 /var/www/vendor/chi-teck/drupal-code-generator/src/Application.php(99): DrupalCodeGenerator\GeneratorFactory->getGenerators()
#4 /var/www/vendor/drush/drush/src/Commands/generate/ApplicationFactory.php(35): DrupalCodeGenerator\Application::create(Object(Drupal\Core\DependencyInjection\Container))
#5 /var/www/vendor/drush/drush/src/Commands/generate/GenerateCommands.php(60): Drush\Commands\generate\ApplicationFactory->create()
#6 [internal function]: Drush\Commands\generate\GenerateCommands->generate('', Array)
#7 /var/www/vendor/consolidation/annotated-command/src/CommandProcessor.php(276): call_user_func_array(Array, Array)
#8 /var/www/vendor/consolidation/annotated-command/src/CommandProcessor.php(212): Consolidation\AnnotatedCommand\CommandProcessor->runCommandCallback(Array, Object(Consolidation\AnnotatedCommand\CommandData))
#9 /var/www/vendor/consolidation/annotated-command/src/CommandProcessor.php(176): Consolidation\AnnotatedCommand\CommandProcessor->validateRunAndAlter(Array, Array, Object(Consolidation\AnnotatedCommand\CommandData))
#10 /var/www/vendor/consolidation/annotated-command/src/AnnotatedCommand.php(391): Consolidation\AnnotatedCommand\CommandProcessor->process(Object(Symfony\Component\Console\Output\ConsoleOutput), Array, Array, Object(Consolidation\AnnotatedCommand\CommandData))
#11 /var/www/vendor/symfony/console/Command/Command.php(326): Consolidation\AnnotatedCommand\AnnotatedCommand->execute(Object(Symfony\Component\Console\Input\ArgvInput), Object(Symfony\Component\Console\Output\ConsoleOutput))
#12 /var/www/vendor/symfony/console/Application.php(1096): Symfony\Component\Console\Command\Command->run(Object(Symfony\Component\Console\Input\ArgvInput), Object(Symfony\Component\Console\Output\ConsoleOutput))
#13 /var/www/vendor/symfony/console/Application.php(324): Symfony\Component\Console\Application->doRunCommand(Object(Consolidation\AnnotatedCommand\AnnotatedCommand), Object(Symfony\Component\Console\Input\ArgvInput), Object(Symfony\Component\Console\Output\ConsoleOutput))
#14 /var/www/vendor/symfony/console/Application.php(175): Symfony\Component\Console\Application->doRun(Object(Symfony\Component\Console\Input\ArgvInput), Object(Symfony\Component\Console\Output\ConsoleOutput))
#15 /var/www/vendor/drush/drush/src/Runtime/Runtime.php(110): Symfony\Component\Console\Application->run(Object(Symfony\Component\Console\Input\ArgvInput), Object(Symfony\Component\Console\Output\ConsoleOutput))
#16 /var/www/vendor/drush/drush/src/Runtime/Runtime.php(40): Drush\Runtime\Runtime->doRun(Array, Object(Symfony\Component\Console\Output\ConsoleOutput))
#17 /var/www/vendor/drush/drush/drush.php(139): Drush\Runtime\Runtime->run(Array)
#18 /var/www/vendor/drush/drush/drush(4): require('/var/www/vendor...')
#19 /var/www/vendor/bin/drush(119): include('/var/www/vendor...')
#20 {main}. 
`

I saw this issue:
https://www.drupal.org/project/colorbox/issues/3280948

And applied the same fix, and it worked, it seems that:
The method definition for SingleDirectoryComponent::__construct() uses LibraryDiscovery as a type hint instead of the interface, which will result in errors if the service implementation is changed.
