### PR TITLE
Declare support for Drupal core  ^10 || ^11 in new modules

### DIFF
--- a/templates/_module/model.info.yml.twig
+++ b/templates/_module/model.info.yml.twig
@@ -2,7 +2,7 @@ name: '{{ name }}'
 type: module
 description: '{{ description }}'
 package: {{ package }}
-core_version_requirement: ^10
+core_version_requirement: ^10 || ^11
 {% if dependencies %}
 dependencies:
   {% for dependency in dependencies %}


### PR DESCRIPTION
This is needed for Drush 11 testing. See https://github.com/drush-ops/drush/pull/5883