### PR TITLE
Update 'chi-teck/drupal-coder-extension' and phpcs.xml config.

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -19,7 +19,7 @@
     "config": {
         "sort-packages": true,
         "allow-plugins": {
-            "dealerdirect/phpcodesniffer-composer-installer": false
+            "dealerdirect/phpcodesniffer-composer-installer": true
         }
     },
     "require": {
@@ -35,7 +35,7 @@
     },
     "require-dev": {
         "ext-simplexml": "*",
-        "chi-teck/drupal-coder-extension": "^2.0.0-beta2",
+        "chi-teck/drupal-coder-extension": "^2.0.0-beta3",
         "drupal/coder": "8.3.23",
         "drupal/core": "10.3.x-dev",
         "phpspec/prophecy-phpunit": "^2.2",

--- a/phpcs.xml
+++ b/phpcs.xml
@@ -1,13 +1,12 @@
 <?xml version="1.0"?>
 <ruleset name="Drupal Code Generator">
   <description>Drupal Code Generator coding standard</description>
-  <config name="installed_paths" value="vendor/slevomat/coding-standard" />
   <arg name="colors"/>
   <file>./scripts</file>
   <file>./src</file>
   <file>./tests</file>
 
-  <rule ref="vendor/chi-teck/drupal-coder-extension/DrupalExtended">
+  <rule ref="DrupalExtended">
     <exclude name="SlevomatCodingStandard.PHP.RequireExplicitAssertion.RequiredExplicitAssertion"/>
     <exclude name="SlevomatCodingStandard.ControlStructures.RequireMultiLineTernaryOperator.MultiLineTernaryOperatorNotUsed"/>
     <!-- Conflicts with PHP attributes. -->


### PR DESCRIPTION
- Update dependency `chi-teck/drupal-coder-extension` to `^2.0.0-beta3`
- Allow `dealerdirect/phpcodesniffer-composer-installer` plugin, to automatically detect PHPCS standards.
- Remove `<config name="installed_paths" value="vendor/slevomat/coding-standard" />` from `phpcs.xml`, because it overrides all available standards.
- Replace relative paths to standards in `phpcs.xml` by their names.