### PR TITLE
Logger: Cast message to string before passing it to strtr

### DIFF
--- a/templates/Service/_logger/logger.twig
+++ b/templates/Service/_logger/logger.twig
@@ -34,6 +34,8 @@ final class {{ class }} implements LoggerInterface {
    * {@inheritdoc}
    */
   public function log($level, string|\Stringable $message, array $context = []): void {
+    // Cast message to string
+    $message = (string) $message;
     // Convert PSR3-style messages to \Drupal\Component\Render\FormattableMarkup
     // style, so they can be translated too.
     $placeholders = $this->parser->parseMessagePlaceholders($message, $context);

--- a/templates/Service/_logger/logger.twig
+++ b/templates/Service/_logger/logger.twig
@@ -34,7 +34,6 @@ final class {{ class }} implements LoggerInterface {
    * {@inheritdoc}
    */
   public function log($level, string|\Stringable $message, array $context = []): void {
-    // Cast message to string
     $message = (string) $message;
     // Convert PSR3-style messages to \Drupal\Component\Render\FormattableMarkup
     // style, so they can be translated too.


### PR DESCRIPTION
Since the logger template is using strict types, it is necessary to explicitly cast the `$message` variable to a `string` before it is passed into `strtr`. Otherwise the following error is generated when a stringable gets logged:

`TypeError: strtr(): Argument #1 ($string) must be of type string`

See also php/php-src#12097 for more details.