### PR TITLE
Fix typo in the migrations directory name

### DIFF
--- a/src/Command/Yml/Migration.php
+++ b/src/Command/Yml/Migration.php
@@ -89,7 +89,7 @@ final class Migration extends BaseGenerator implements ContainerInjectionInterfa
       $vars['fields'] = \array_keys($field_map[$entity_type] ?? []);
     }
 
-    $assets->addFile('migration/{plugin_id}.yml', 'migration.twig');
+    $assets->addFile('migrations/{plugin_id}.yml', 'migration.twig');
   }
 
 }


### PR DESCRIPTION
The migration plugins are only discovered when they are located in the [migrations](https://git.drupalcode.org/project/drupal/-/blob/11.x/core/modules/migrate/src/Plugin/MigrationPluginManager.php?ref_type=heads#L72) (plural) directory.