### PR TITLE
Update core version requirement to include version 12

### DIFF
--- a/templates/Yaml/_module-info/module-info.twig
+++ b/templates/Yaml/_module-info/module-info.twig
@@ -2,7 +2,7 @@ name: {{ name }}
 type: module
 description: {{ description }}
 package: {{ package }}
-core_version_requirement: ^10 || ^11
+core_version_requirement: ^10 || ^11 || ^12
 {% if dependencies %}
 dependencies:
 {% for dependency in dependencies %}


### PR DESCRIPTION
Needed for Drush's own tests to pass when using Drupal `main` branch. 