### PR TITLE
Allow Symfony 8

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -27,10 +27,10 @@
         "ext-json": "*",
         "psr/event-dispatcher": "^1.0",
         "psr/log": "^3.0",
-        "symfony/console": "^7.1",
-        "symfony/dependency-injection": "^7.1",
-        "symfony/filesystem": "^7.1",
-        "symfony/string": "^7.0",
+        "symfony/console": "^7.1 || ^8",
+        "symfony/dependency-injection": "^7.1 || ^8",
+        "symfony/filesystem": "^7.1 || ^8",
+        "symfony/string": "^7.0 || ^8",
         "twig/twig": "^3.4"
     },
     "require-dev": {
@@ -41,8 +41,8 @@
         "phpspec/prophecy-phpunit": "^2.2",
         "phpunit/phpunit": "^10.5",
         "squizlabs/php_codesniffer": "^3.9",
-        "symfony/var-dumper": "^7.1",
-        "symfony/yaml": "^7.1",
+        "symfony/var-dumper": "^7.1 || ^8",
+        "symfony/yaml": "^7.1 || ^8",
         "vimeo/psalm": "^5.24.0"
     },
     "conflict": {


### PR DESCRIPTION
Widen symfony/* constraints to allow ^8.

No code changes needed — the APIs used by this package are unchanged in Symfony 8.

Ref: https://github.com/drush-ops/drush/issues/6536