### PR TITLE
Issue in generated entity code (hasPermission)

### DIFF
--- a/templates/Entity/_content-entity/src/ExampleAccessControlHandler.php.twig
+++ b/templates/Entity/_content-entity/src/ExampleAccessControlHandler.php.twig
@@ -22,7 +22,8 @@ final class {{ class }}AccessControlHandler extends EntityAccessControlHandler {
    * {@inheritdoc}
    */
   protected function checkAccess(EntityInterface $entity, $operation, AccountInterface $account): AccessResult {
-    if ($account->hasPermission($this->entityType->getAdminPermission())) {
+    $permission = $this->entityType->getAdminPermission();
+    if (is_string($permission) && $account->hasPermission($permission)) {
       return AccessResult::allowed()->cachePerPermissions();
     }
 


### PR DESCRIPTION
Code produced by Drush has an issue that only became apparent at PHPStan level 8. See https://www.drupal.org/project/drupal/issues/3587247 and https://www.drupal.org/project/drupal/issues/3416110

This hasn't caused a problem for me, but might for others in some cases.

This change checks that the return of getAdminPermission is a string before calling hasPermission.