### PR TITLE
Update README template to better align with drupal.org template

### DIFF
--- a/templates/_module/README.md.twig
+++ b/templates/_module/README.md.twig
@@ -16,8 +16,9 @@ DESCRIBE_MODULE_DEPENDENCIES_HERE
 
 ## Installation
 
-Install as you would normally install a contributed Drupal module.
-See: https://www.drupal.org/node/895232 for further information.
+Install as you would normally install a contributed Drupal module. For further
+information, see
+[Installing Drupal Modules](https://www.drupal.org/docs/extending-drupal/installing-modules).
 
 
 ## Configuration

--- a/templates/_module/README.md.twig
+++ b/templates/_module/README.md.twig
@@ -1,4 +1,4 @@
-## INTRODUCTION
+# {{ name }}
 
 The {{ name }} module is a DESCRIBE_THE_MODULE_HERE.
 
@@ -8,23 +8,28 @@ The primary use case for this module is:
 - Use case #2
 - Use case #3
 
-## REQUIREMENTS
+
+## Requirements
 
 DESCRIBE_MODULE_DEPENDENCIES_HERE
 
-## INSTALLATION
+
+## Installation
 
 Install as you would normally install a contributed Drupal module.
 See: https://www.drupal.org/node/895232 for further information.
 
-## CONFIGURATION
+
+## Configuration
+
 - Configuration step #1
 - Configuration step #2
 - Configuration step #3
 
-## MAINTAINERS
 
-Current maintainers for Drupal 10:
+## Maintainers
+
+Current maintainers for Drupal 11:
 
 - FIRST_NAME LAST_NAME (NICKNAME) - https://www.drupal.org/u/NICKNAME
 

--- a/tests/functional/Generator/_module/foo/README.md
+++ b/tests/functional/Generator/_module/foo/README.md
@@ -16,8 +16,9 @@ DESCRIBE_MODULE_DEPENDENCIES_HERE
 
 ## Installation
 
-Install as you would normally install a contributed Drupal module.
-See: https://www.drupal.org/node/895232 for further information.
+Install as you would normally install a contributed Drupal module. For further
+information, see
+[Installing Drupal Modules](https://www.drupal.org/docs/extending-drupal/installing-modules).
 
 
 ## Configuration

--- a/tests/functional/Generator/_module/foo/README.md
+++ b/tests/functional/Generator/_module/foo/README.md
@@ -1,4 +1,4 @@
-## INTRODUCTION
+# Foo
 
 The Foo module is a DESCRIBE_THE_MODULE_HERE.
 
@@ -8,23 +8,28 @@ The primary use case for this module is:
 - Use case #2
 - Use case #3
 
-## REQUIREMENTS
+
+## Requirements
 
 DESCRIBE_MODULE_DEPENDENCIES_HERE
 
-## INSTALLATION
+
+## Installation
 
 Install as you would normally install a contributed Drupal module.
 See: https://www.drupal.org/node/895232 for further information.
 
-## CONFIGURATION
+
+## Configuration
+
 - Configuration step #1
 - Configuration step #2
 - Configuration step #3
 
-## MAINTAINERS
 
-Current maintainers for Drupal 10:
+## Maintainers
+
+Current maintainers for Drupal 11:
 
 - FIRST_NAME LAST_NAME (NICKNAME) - https://www.drupal.org/u/NICKNAME
 


### PR DESCRIPTION
The tool works great, and I just generated a module with it.

I did notice that there a few differences between the resulting README and the drupal.org [README.md template](https://www.drupal.org/docs/develop/managing-a-drupalorg-theme-module-or-distribution-project/documenting-your-project/readmemd-template), so perhaps we can make a few adjustments, to better align them?

This would also allow us to remove this tip on the [README.md template](https://www.drupal.org/docs/develop/managing-a-drupalorg-theme-module-or-distribution-project/documenting-your-project/readmemd-template) page:

> You can generate a boilerplate README.md with the following command: `drush generate readme`. The generated text does not follow these guidelines exactly, but may serve as a good starting point.


The PR makes these changes:

- Project name is the first line of the document, and only level one heading (`#`)
- Headings capitalized with an initial capital, following standard English sentence rules
- Two lines prior to `##`/`###` headings
- Link module installation to current Drupal 11 page (was Drupal 7)
